### PR TITLE
Added the possibility to add the Minimap outside the map.

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -56,9 +56,9 @@
 			this._mainMap = map;
 
 			// Creating the container and stopping events from spilling through to the main map.
-			this._container = L.DomUtil.create('div', 'leaflet-control-minimap');
-			this._container.style.width = this.options.width + 'px';
-			this._container.style.height = this.options.height + 'px';
+            		this._container = L.DomUtil.create('div', (this.options.class == undefined) ? 'leaflet-control-minimap' : this.options.class);
+		 	this._container.style.width = this.options.width;
+            		this._container.style.height = this.options.height;
 			L.DomEvent.disableClickPropagation(this._container);
 			L.DomEvent.on(this._container, 'mousewheel', L.DomEvent.stopPropagation);
 
@@ -105,9 +105,16 @@
 			return this._container;
 		},
 
-		addTo: function (map) {
-			L.Control.prototype.addTo.call(this, map);
-
+		addTo: function (map, parent = undefined) {
+			if(parent == undefined)
+			{
+                		L.Control.prototype.addTo.call(this, map);
+            		}
+            		else
+			{
+                		var container = this.onAdd(map);
+				parent.appendChild(container);
+		 	}
 			var center = this.options.centerFixed || this._mainMap.getCenter();
 			this._miniMap.setView(center, this._decideZoom(true));
 			this._setDisplay(this.options.minimized);


### PR DESCRIPTION
I've added a parent argument in the addTo function of the script, which is useful if you want your MiniMap to be outside of the MainMap.
Also, according to that, I've added an option to set a custom class to the container of the Minimap, and I removed the px string to be able to set in pourcentage and not only in pixels, which is useful if you want it to be 100% in his parent.